### PR TITLE
Removed `autocompleteText`

### DIFF
--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -636,13 +636,6 @@ export default {
     autocomplete: null,
 
     /**
-     * Autocomplete input text
-     * @access private
-     * @type {String}
-     */
-    autocompleteText: '',
-
-    /**
      * Indicates if the Geolocate has already been set.
      * @access private
      */
@@ -687,7 +680,7 @@ export default {
      * @access private
      */
     onChange() {
-      this.$emit('change', this.autocompleteText);
+      this.$emit('change', this.value);
     },
 
     /**
@@ -704,7 +697,7 @@ export default {
      * @access private
      */
     clear() {
-      this.autocompleteText = '';
+      this.value = '';
     },
 
     /**
@@ -729,7 +722,7 @@ export default {
      * @access private
      */
     update(value) {
-      this.autocompleteText = value;
+      this.value = value;
     },
 
     /**
@@ -817,19 +810,12 @@ export default {
           // return returnData object and PlaceResult object
           this.$emit('placechanged', returnData, place, this.id);
 
-          // update autocompleteText then emit change event
-          this.autocompleteText = document.getElementById(this.id).value;
+          // update value then emit change event
+          this.value = document.getElementById(this.id).value;
           this.onChange();
         }
       });
     },
-  },
-  /**
-   * @mixin
-   * @desc Updates the autocompleteText member if a v-model was provided.
-   */
-  created() {
-    this.autocompleteText = this.value ? this.value : '';
   },
   /**
    * @mixin
@@ -912,15 +898,12 @@ export default {
         textarea: self.textarea,
         'toggle-keys': self.toggleKeys,
         type: self.type,
-        value: self.value || self.autocompleteText,
+        value: self.value,
         'validate-on-blur': self.validateOnBlur,
         '@focus': self.onFocus(),
         '@blur': self.onFocus(),
         '@change': self.onChange(),
         '@keypress': self.onKeyPress(),
-      },
-      domProps: {
-        // value: self.autocompleteText,
       },
       on: {
         focus: () => {
@@ -941,7 +924,7 @@ export default {
             self.$emit('input', event.target.value);
           } else {
             // clear was pressed, reset this
-            self.autocompleteText = '';
+            self.value = '';
             self.$emit('placechanged', null);
           }
         },
@@ -955,7 +938,7 @@ export default {
     /**
     * Emit the new autocomplete text whenever it changes.
     */
-    autocompleteText: function autocompleteText(newVal) {
+    value: function value(newVal) {
       this.$emit('input', newVal || '');
     },
 

--- a/test/unit/specs/Data.spec.js
+++ b/test/unit/specs/Data.spec.js
@@ -21,13 +21,13 @@ describe('Ensure component data properties behave as expected', () => {
     });
   });
 
-  describe('autocompleteText', () => {
-    test('Should have "" as default', () => {
+  describe('value', () => {
+    test('Should have "undefined" as default', () => {
       const wrapper = mount(Vga, {
         localVue,
         propsData: mandatoryProps,
       });
-      expect(wrapper.vm.autocompleteText).toBe('');
+      expect(wrapper.vm.value).toBeUndefined();
     });
   });
 

--- a/test/unit/specs/Init.spec.js
+++ b/test/unit/specs/Init.spec.js
@@ -30,7 +30,7 @@ describe('Ensure Has correct init meta data', () => {
 
 describe('Ensure Lifecycle hooks behave as expected', () => {
   describe('Created', () => {
-    test('Should set autocompleteText propertly if v-model provided', () => {
+    test('Should set value propertly if v-model provided', () => {
       const props = {
         id: 'a prop',
         value: 'Default v-model value',
@@ -39,11 +39,11 @@ describe('Ensure Lifecycle hooks behave as expected', () => {
         localVue,
         propsData: props,
       });
-      expect(wrapper.vm.autocompleteText).toBe('Default v-model value');
+      expect(wrapper.vm.value).toBe('Default v-model value');
     });
 
-    test('Should set autocompleteText propertly if v-model NOT provided', () => {
-      expect(wrapper.vm.autocompleteText).toBe('');
+    test('Should set value propertly if v-model NOT provided', () => {
+      expect(wrapper.vm.value).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Removed `autocompleteText` - just use `value` to enable vee-validate validation without having to attach `v-model`