### PR TITLE
Add language option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ import VuetifyGoogleAutocomplete from 'vuetify-google-autocomplete';
 Vue.use(VuetifyGoogleAutocomplete, {
   apiKey: '...', // Can also be an object. E.g, for Google Maps Premium API, pass `{ client: <YOUR-CLIENT-ID> }`
   version: '...', // Optional
+  language: '...', // Optional
 });
 ```
 

--- a/src/vga/helper.js
+++ b/src/vga/helper.js
@@ -10,7 +10,7 @@
  * @see {@link https://github.com/xkjyeah/vue-google-maps}
  * @access private
  */
-const loadGoogleMaps = (apiKey, version) => {
+const loadGoogleMaps = (apiKey, version, language) => {
   try {
     // If not within browser context, do not continue processing.
     if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -53,6 +53,10 @@ const loadGoogleMaps = (apiKey, version) => {
 
       if (version) {
         url = `${url}&v=${version}`;
+      }
+
+      if (language) {
+        url = `${url}&language=${language}`;
       }
 
       googleMapScript.setAttribute('src', url);

--- a/src/vga/index.js
+++ b/src/vga/index.js
@@ -14,7 +14,7 @@ if (typeof window !== 'undefined') {
 
 VuetifyGoogleAutocomplete.install = (Vue, options) => {
   if (options.apiKey) {
-    loadGoogleMaps(options.apiKey, options.version);
+    loadGoogleMaps(options.apiKey, options.version, options.language);
   }
 
   Vue.component(VuetifyGoogleAutocomplete.name, VuetifyGoogleAutocomplete);


### PR DESCRIPTION
Closes [#65](https://github.com/MadimetjaShika/vuetify-google-autocomplete/issues/65)

Allows adding language to the API url:
https://maps.googleapis.com/maps/api/js?key=API_KEY&libraries=places&language=LANGUAGE

Usage:
```
Vue.use(VuetifyGoogleAutocomplete, {
  apiKey: API_KEY,
  language: LANGUAGE
});
```