### PR TITLE
Couple small fixes

### DIFF
--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -705,6 +705,7 @@ export default {
      */
     clear() {
       this.autocompleteText = '';
+      this.$refs.textField.clearableCallback();
     },
 
     /**
@@ -859,6 +860,7 @@ export default {
   render(createElement) {
     const self = this;
     return createElement('v-text-field', {
+      ref: 'textField',
       attrs: {
         id: self.id,
         name: self.id,

--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -783,7 +783,7 @@ export default {
       this.autocomplete.addListener('place_changed', () => {
         const place = this.autocomplete.getPlace();
 
-        if (!place.geometry) {
+        if (!place || !place.geometry) {
           // User entered the name of a Place that was not suggested and
           // pressed the Enter key, or the Place Details request failed.
           this.$emit('no-results-found', place);


### PR DESCRIPTION
* When invoking `clear` on the autocomplete component, the value from the underlying text field wasn't being completely cleared - this fixes that by invoking the vuetify `clearCallback` function

* Fixes an edge condition when google autocomplete fails to return a `place` and the check for `place.geometry` raises a `Uncaught TypeError: Cannot read property 'here' of null` or `Uncaught TypeError: Cannot read property 'here' of undefined` (can't remember wether it was null or undefined I was seeing, but this fixes either)