### PR TITLE
Add a fields prop to allow limiting the data that is requested

### DIFF
--- a/JSDOCS.md
+++ b/JSDOCS.md
@@ -28,6 +28,7 @@ For more detailed HTML output of the JSDocs, refer to the ``./docs`` directory.
         * [.enable-geolocation](#module_vuetify-google-autocomplete.props.enable-geolocation) : <code>Boolean</code>
         * [.error](#module_vuetify-google-autocomplete.props.error) : <code>Boolean</code>
         * [.error-messages](#module_vuetify-google-autocomplete.props.error-messages) : <code>Array</code>
+        * [.fields](#module_vuetify-google-autocomplete.props.fields) : <code>String</code> \| <code>Array</code>
         * [.flat](#module_vuetify-google-autocomplete.props.flat) : <code>Boolean</code>
         * [.full-width](#module_vuetify-google-autocomplete.props.full-width) : <code>Boolean</code>
         * [.hide-details](#module_vuetify-google-autocomplete.props.hide-details) : <code>Boolean</code>
@@ -73,6 +74,7 @@ For more detailed HTML output of the JSDocs, refer to the ``./docs`` directory.
     * [.watch](#module_vuetify-google-autocomplete.watch)
         * [.autocompleteText()](#module_vuetify-google-autocomplete.watch.autocompleteText)
         * [.country()](#module_vuetify-google-autocomplete.watch.country)
+        * [.fields()](#module_vuetify-google-autocomplete.watch.fields)
         * [.enableGeolocation()](#module_vuetify-google-autocomplete.watch.enableGeolocation)
         * [.types()](#module_vuetify-google-autocomplete.watch.types)
     * [.name](#module_vuetify-google-autocomplete.name)
@@ -104,6 +106,7 @@ Exposed component props.
     * [.enable-geolocation](#module_vuetify-google-autocomplete.props.enable-geolocation) : <code>Boolean</code>
     * [.error](#module_vuetify-google-autocomplete.props.error) : <code>Boolean</code>
     * [.error-messages](#module_vuetify-google-autocomplete.props.error-messages) : <code>Array</code>
+    * [.fields](#module_vuetify-google-autocomplete.props.fields) : <code>String</code> \| <code>Array</code>
     * [.flat](#module_vuetify-google-autocomplete.props.flat) : <code>Boolean</code>
     * [.full-width](#module_vuetify-google-autocomplete.props.full-width) : <code>Boolean</code>
     * [.hide-details](#module_vuetify-google-autocomplete.props.hide-details) : <code>Boolean</code>
@@ -261,6 +264,14 @@ Maps to Vuetify 'error-messages' prop.
 
 **Kind**: static property of [<code>props</code>](#module_vuetify-google-autocomplete.props)  
 **See**: [https://vuetifyjs.com/en/components/text-fields](https://vuetifyjs.com/en/components/text-fields)  
+<a name="module_vuetify-google-autocomplete.props.fields"></a>
+
+#### props.fields : <code>String</code> \| <code>Array</code>
+Fields to be included for the Place in the details response when the details
+are successfully retrieved, which will be billed for.
+
+**Kind**: static property of [<code>props</code>](#module_vuetify-google-autocomplete.props)  
+**See**: [https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.fields](https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.fields)  
 <a name="module_vuetify-google-autocomplete.props.flat"></a>
 
 #### props.flat : <code>Boolean</code>
@@ -560,6 +571,7 @@ See code.
 * [.watch](#module_vuetify-google-autocomplete.watch)
     * [.autocompleteText()](#module_vuetify-google-autocomplete.watch.autocompleteText)
     * [.country()](#module_vuetify-google-autocomplete.watch.country)
+    * [.fields()](#module_vuetify-google-autocomplete.watch.fields)
     * [.enableGeolocation()](#module_vuetify-google-autocomplete.watch.enableGeolocation)
     * [.types()](#module_vuetify-google-autocomplete.watch.types)
 
@@ -573,6 +585,12 @@ Emit the new autocomplete text whenever it changes.
 
 #### watch.country()
 Update the SDK country option whenever it changes from the parent.
+
+**Kind**: static method of [<code>watch</code>](#module_vuetify-google-autocomplete.watch)  
+<a name="module_vuetify-google-autocomplete.watch.fields"></a>
+
+#### watch.fields()
+Update the SDK fields option whenever it changes from the parent.
 
 **Kind**: static method of [<code>watch</code>](#module_vuetify-google-autocomplete.watch)  
 <a name="module_vuetify-google-autocomplete.watch.enableGeolocation"></a>

--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -4,8 +4,8 @@
  */
 export default {
   /**
-  * Component name. Returns 'vuetify-google-autocomplete'.
-  */
+   * Component name. Returns 'vuetify-google-autocomplete'.
+   */
   name: 'vuetify-google-autocomplete',
   /**
    * @mixin
@@ -224,6 +224,15 @@ export default {
     errorMessages: {
       type: Array,
       default: () => [],
+    },
+    /**
+     * Fields to be included for the Place in the details response when the details are successfully retrieved, which will be billed for.
+     * @see {@link https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.fields}
+     * @type {String|Array}
+     */
+    fields: {
+      type: [String, Array],
+      default: null,
     },
     /**
      * Maps to Vuetify 'flat' prop.
@@ -733,10 +742,10 @@ export default {
     },
 
     /**
-    * Bias the autocomplete object to the user's geographical location,
-    * as supplied by the browser's 'navigator.geolocation' object.
-    * @access private
-    */
+     * Bias the autocomplete object to the user's geographical location,
+     * as supplied by the browser's 'navigator.geolocation' object.
+     * @access private
+     */
     geolocate() {
       if (this.enableGeolocation && !this.geolocateSet) {
         if (navigator.geolocation) {
@@ -767,6 +776,14 @@ export default {
         options.componentRestrictions = {
           country: this.country,
         };
+      }
+
+      if (this.fields) {
+        if (typeof this.fields == "string") {
+          options.fields = [this.fields];
+        } else {
+          options.fields = this.fields;
+        }
       }
 
       this.autocomplete = new window.google.maps.places.Autocomplete(
@@ -939,7 +956,7 @@ export default {
           if (event && event.target) {
             self.value = event.target.value;
             self.$emit('input', event.target.value);
-          } else {
+          } else if (!event) {
             // clear was pressed, reset this
             self.autocompleteText = '';
             self.$emit('placechanged', null);
@@ -953,15 +970,15 @@ export default {
    */
   watch: {
     /**
-    * Emit the new autocomplete text whenever it changes.
-    */
+     * Emit the new autocomplete text whenever it changes.
+     */
     autocompleteText: function autocompleteText(newVal) {
       this.$emit('input', newVal || '');
     },
 
     /**
-    * Update the SDK country option whenever it changes from the parent.
-    */
+     * Update the SDK country option whenever it changes from the parent.
+     */
     country: function country(newVal) {
       if (newVal) {
         this.autocomplete.componentRestrictions.country = newVal;
@@ -969,8 +986,21 @@ export default {
     },
 
     /**
-    * Watches for changes on the Geolocation option.
-    */
+     * Update the SDK fields option whenever it changes from the parent.
+     */
+    fields: function fields(newVal) {
+      if (newVal) {
+        if (typeof newVal == "string") {
+          this.fields = [newVal];
+        } else {
+          this.fields = newVal;
+        }
+      }
+    },
+
+    /**
+     * Watches for changes on the Geolocation option.
+     */
     enableGeolocation: function enableGeolocation(newVal) {
       if (!newVal) {
         this.geolocateSet = false;
@@ -986,8 +1016,8 @@ export default {
     },
 
     /**
-    * Update the SDK types option whenever it changes from the parent.
-    */
+     * Update the SDK types option whenever it changes from the parent.
+     */
     types: function types(newVal) {
       if (newVal) {
         this.autocomplete.setTypes([this.types]);

--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -799,7 +799,7 @@ export default {
       this.autocomplete.addListener('place_changed', () => {
         const place = this.autocomplete.getPlace();
 
-        if (!place.geometry) {
+        if (Object.keys(place).length < 2) {
           // User entered the name of a Place that was not suggested and
           // pressed the Enter key, or the Place Details request failed.
           this.$emit('no-results-found', place);
@@ -822,14 +822,18 @@ export default {
               returnData[addressType] = val;
             }
           }
-
-          returnData.latitude = place.geometry.location.lat();
-          returnData.longitude = place.geometry.location.lng();
+          if (place.geometry) {
+            returnData.latitude = place.geometry.location.lat();
+            returnData.longitude = place.geometry.location.lng();
+          }
 
           // additional fields available in google places results
-          returnData.name = place.name;
-          returnData.photos = place.photos;
-          returnData.place_id = place.place_id;
+          if (place.name)
+            returnData.name = place.name;
+          if (place.photos)
+            returnData.photos = place.photos;
+          if (place.place_id)
+            returnData.place_id = place.place_id;
 
           // return returnData object and PlaceResult object
           this.$emit('placechanged', returnData, place, this.id);
@@ -991,9 +995,9 @@ export default {
     fields: function fields(newVal) {
       if (newVal) {
         if (typeof newVal == "string") {
-          this.fields = [newVal];
+          this.setFields([newVal]);
         } else {
-          this.fields = newVal;
+          this.setFields(newVal);
         }
       }
     },

--- a/src/vga/VuetifyGoogleAutocomplete.js
+++ b/src/vga/VuetifyGoogleAutocomplete.js
@@ -226,7 +226,8 @@ export default {
       default: () => [],
     },
     /**
-     * Fields to be included for the Place in the details response when the details are successfully retrieved, which will be billed for.
+     * Fields to be included for the Place in the details response when the details
+     * are successfully retrieved, which will be billed for.
      * @see {@link https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.fields}
      * @type {String|Array}
      */
@@ -779,7 +780,7 @@ export default {
       }
 
       if (this.fields) {
-        if (typeof this.fields == "string") {
+        if (typeof this.fields === 'string') {
           options.fields = [this.fields];
         } else {
           options.fields = this.fields;
@@ -828,12 +829,15 @@ export default {
           }
 
           // additional fields available in google places results
-          if (place.name)
+          if (place.name) {
             returnData.name = place.name;
-          if (place.photos)
+          }
+          if (place.photos) {
             returnData.photos = place.photos;
-          if (place.place_id)
+          }
+          if (place.place_id) {
             returnData.place_id = place.place_id;
+          }
 
           // return returnData object and PlaceResult object
           this.$emit('placechanged', returnData, place, this.id);
@@ -994,7 +998,7 @@ export default {
      */
     fields: function fields(newVal) {
       if (newVal) {
-        if (typeof newVal == "string") {
+        if (typeof newVal === 'string') {
           this.setFields([newVal]);
         } else {
           this.setFields(newVal);


### PR DESCRIPTION
By default, the places API will retrieve all known data once a place is selected from the autocomplete. This means not only are you potentially retrieving unneeded data, but you are incurring extra charges for no apparent reason (for example, turning the 0.17 cent request into a 0.20 cent request).

This property allows you to limit what is returned, saving both data and money.