### PR TITLE
Add selection-required prop

### DIFF
--- a/test/unit/specs/Props.spec.js
+++ b/test/unit/specs/Props.spec.js
@@ -104,6 +104,25 @@ describe('Ensure component props behave as expected', () => {
     });
   });
 
+  describe('selection-required', () => {
+    test('Should have false as default if not provided', () => {
+      const wrapper = mount(Vga, {
+        localVue,
+        propsData: mandatoryProps,
+      });
+      expect(wrapper.vm.$props.selectionRequired).toBe(false);
+    });
+
+    test('Should accept boolean input', () => {
+      mandatoryProps.selectionRequired = true;
+      const wrapper = mount(Vga, {
+        localVue,
+        propsData: mandatoryProps,
+      });
+      expect(wrapper.vm.$props.selectionRequired).toBe(true);
+    });
+  });
+
   describe('background-color', () => {
     test('Should have false as default if not provided', () => {
       const wrapper = mount(Vga, {


### PR DESCRIPTION
Added a new selection-required prop. If it is set to true then a rule is added to the underlying v-text-field that requires that the user selects an address from the search results.

Fixes #89 